### PR TITLE
feat: migrate email service from SendGrid to Resend

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -33,8 +33,8 @@ class Settings(BaseSettings):
     ALGORITHM: Literal["HS256"] = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
 
-    # --- Variables para envíos de correo con SendGrid ---
-    SENDGRID_API_KEY: str
+    # --- Variables para envíos de correo con Resend ---
+    RESEND_API_KEY: str
     MAIL_FROM: EmailStr # Usamos EmailStr para validar
 
     # --- URL base de tu Frontend (para construir links de reset/verificación) ---

--- a/api/app/email_utils.py
+++ b/api/app/email_utils.py
@@ -3,8 +3,7 @@
 import os
 from typing import List
 from datetime import datetime
-from sendgrid import SendGridAPIClient
-from sendgrid.helpers.mail import Mail
+import resend
 from .config import settings
 from . import schemas
 
@@ -50,19 +49,21 @@ def _create_styled_html_content(title: str, body_html: str) -> str:
 
 def send_email(to_email: str, subject: str, html_content: str) -> bool:
     """
-    Generic function to send an email using SendGrid.
+    Generic function to send an email using Resend.
     """
-    message = Mail(
-        from_email=settings.MAIL_FROM,
-        to_emails=to_email,
-        subject=subject,
-        html_content=html_content
-    )
     try:
-        sg = SendGridAPIClient(settings.SENDGRID_API_KEY)
-        response = sg.send(message)
-        print(f"Email sent to {to_email}, status code: {response.status_code}")
-        return response.status_code in [200, 202]
+        resend.api_key = settings.RESEND_API_KEY
+        
+        params = {
+            "from": settings.MAIL_FROM,
+            "to": [to_email],
+            "subject": subject,
+            "html": html_content,
+        }
+        
+        response = resend.send(params)
+        print(f"Email sent to {to_email}, response: {response}")
+        return True
     except Exception as e:
         print(f"Error sending email to {to_email}: {e}")
         return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,6 +71,6 @@ urllib3==2.4.0
 uvicorn==0.34.2
 websockets==15.0.1
 yarl==1.20.0
-sendgrid
+resend
 web3
 slowapi


### PR DESCRIPTION
- Replace SendGrid dependencies with Resend in requirements.txt
- Update email_utils.py to use Resend API instead of SendGrid
- Simplify email sending logic with Resend's cleaner API
- Update config.py to use RESEND_API_KEY instead of SENDGRID_API_KEY
- All email functions now use Resend: verification, reset, alerts, contact form